### PR TITLE
MPC sign transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ An application to measure the end user latency of transactions on the Near block
 - Token transfer with [`wait_until: Final`](https://docs.near.org/api/rpc/transactions#tx-status-result)
 - Swap NEAR -> USDT
 - FT USDT transfer
+- MPC Sign requests
 
 ## Usage
 Run locally with `cargo` or build and run as a docker image:

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,9 @@ pub struct Opts {
     /// Exchange account id, used for swap
     #[clap(long, env)]
     pub exchange_id: AccountId,
+    /// MPC Contract account, used for MPC Sign
+    #[clap(long, env)]
+    pub mpc_contract_id: AccountId,
     /// Pool id for swap command
     #[clap(long, env)]
     pub pool_id: u32,

--- a/src/transaction/engine.rs
+++ b/src/transaction/engine.rs
@@ -326,6 +326,7 @@ mod tests {
             signer_id: "cat.near".parse().unwrap(),
             signer_key: SecretKey::from_random(KeyType::ED25519),
             receiver_id: "dog.near".parse().unwrap(),
+            mpc_contract_id: "frog.near".parse().unwrap(),
             wrap_near_id: "frog.near".parse().unwrap(),
             ft_account_id: "bear.near".parse().unwrap(),
             exchange_id: "flamingo.near".parse().unwrap(),

--- a/src/transaction/engine.rs
+++ b/src/transaction/engine.rs
@@ -10,7 +10,7 @@ use tracing::{error, info, warn};
 use crate::{
     metrics::{Labels, Metrics},
     transaction::{
-        fungible_token_transfer::FungibleTokenTransfer, swap::Swap,
+        fungible_token_transfer::FungibleTokenTransfer, mpc_sign::MpcSign, swap::Swap,
         token_transfer_default::TokenTransferDefault, token_transfer_final::TokenTransferFinal,
         token_transfer_included_final::TokenTransferIncludedFinal,
     },
@@ -45,6 +45,7 @@ impl Engine {
         add_transaction!(TokenTransferIncludedFinal);
         add_transaction!(FungibleTokenTransfer);
         add_transaction!(Swap);
+        add_transaction!(MpcSign);
 
         Engine { transactions }
     }

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -18,6 +18,7 @@ use crate::metrics::{Labels, Metrics};
 pub mod engine;
 
 mod fungible_token_transfer;
+mod mpc_sign;
 mod swap;
 mod token_transfer_default;
 mod token_transfer_final;
@@ -31,6 +32,7 @@ pub enum TransactionKind {
     TokenTransferFinal,
     FungibleTokenTransfer,
     Swap,
+    MpcSign,
 }
 
 #[async_trait]

--- a/src/transaction/mpc_sign.rs
+++ b/src/transaction/mpc_sign.rs
@@ -52,13 +52,3 @@ impl TransactionSample for MpcSign {
         }
     }
 }
-
-// args: &serde_json::to_vec(&SignArgsV2 {
-//     request: SignRequestArgs {
-//         domain_id: Some(domain_config.id),
-//         path: "".to_string(),
-//         payload_v2: Some(payload),
-//         ..Default::default()
-//     },
-// })
-// .unwrap(),

--- a/src/transaction/mpc_sign.rs
+++ b/src/transaction/mpc_sign.rs
@@ -6,8 +6,7 @@ use near_jsonrpc_primitives::types::transactions::RpcSendTransactionRequest;
 use near_primitives::action::FunctionCallAction;
 use near_primitives::hash::CryptoHash;
 use near_primitives::transaction::{Action, Transaction, TransactionV0};
-use near_primitives::types::{AccountId, Nonce};
-use std::str::FromStr;
+use near_primitives::types::Nonce;
 
 use super::TransactionKind;
 
@@ -26,23 +25,21 @@ impl TransactionSample for MpcSign {
     fn get_transaction_request(
         &self,
         signer: InMemorySigner,
-        _opts: Opts,
+        opts: Opts,
         nonce: Nonce,
         block_hash: CryptoHash,
     ) -> RpcSendTransactionRequest {
-        let domain_id = "0";
-        let payload = serde_json::json!({
-            "Ecdsa": vec![1u8; 32]
-        });
+        let key_version = 0;
+        let payload = serde_json::json!(vec![1u8; 32]);
         let transaction = Transaction::V0(TransactionV0 {
             signer_id: signer.account_id.clone(),
             public_key: signer.public_key.clone(),
             nonce: nonce + 1,
-            receiver_id: AccountId::from_str("v1.signer-prod.testnet").unwrap(),
+            receiver_id: opts.mpc_contract_id,
             block_hash,
             actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "sign".to_string(),
-                args: serde_json::json!({"domain_id": domain_id,"path": "","payload_v2": payload})
+                args: serde_json::json!({"request": {"key_version": key_version,"path": "","payload": payload}})
                     .to_string()
                     .into_bytes(),
                 gas: 10_000_000_000_000, // 10 TeraGas

--- a/src/transaction/mpc_sign.rs
+++ b/src/transaction/mpc_sign.rs
@@ -1,0 +1,67 @@
+use crate::config::Opts;
+use crate::TransactionSample;
+use async_trait::async_trait;
+use near_crypto::InMemorySigner;
+use near_jsonrpc_primitives::types::transactions::RpcSendTransactionRequest;
+use near_primitives::action::FunctionCallAction;
+use near_primitives::hash::CryptoHash;
+use near_primitives::transaction::{Action, Transaction, TransactionV0};
+use near_primitives::types::{AccountId, Nonce};
+use std::str::FromStr;
+
+use super::TransactionKind;
+
+pub struct MpcSign {}
+
+#[async_trait]
+impl TransactionSample for MpcSign {
+    fn kind(&self) -> TransactionKind {
+        TransactionKind::MpcSign
+    }
+
+    fn get_name(&self) -> &str {
+        "Call MPC sign function"
+    }
+
+    fn get_transaction_request(
+        &self,
+        signer: InMemorySigner,
+        _opts: Opts,
+        nonce: Nonce,
+        block_hash: CryptoHash,
+    ) -> RpcSendTransactionRequest {
+        let domain_id = "0";
+        let payload = serde_json::json!({
+            "Ecdsa": vec![1u8; 32]
+        });
+        let transaction = Transaction::V0(TransactionV0 {
+            signer_id: signer.account_id.clone(),
+            public_key: signer.public_key.clone(),
+            nonce: nonce + 1,
+            receiver_id: AccountId::from_str("v1.signer-prod.testnet").unwrap(),
+            block_hash,
+            actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
+                method_name: "sign".to_string(),
+                args: serde_json::json!({"domain_id": domain_id,"path": "","payload_v2": payload})
+                    .to_string()
+                    .into_bytes(),
+                gas: 10_000_000_000_000, // 10 TeraGas
+                deposit: 1,
+            }))],
+        });
+        RpcSendTransactionRequest {
+            signed_transaction: transaction.sign(&signer.into()),
+            wait_until: Default::default(),
+        }
+    }
+}
+
+// args: &serde_json::to_vec(&SignArgsV2 {
+//     request: SignRequestArgs {
+//         domain_id: Some(domain_config.id),
+//         path: "".to_string(),
+//         payload_v2: Some(payload),
+//         ..Default::default()
+//     },
+// })
+// .unwrap(),


### PR DESCRIPTION
Tested with :
```
cargo run -- --mode run --transaction-kind=mpc-sign --rpc-url https://rpc.testnet.near.org --signer-id and7.testnet --signer-key "ed25519:myprivatekey" --receiver-id tx-bench-buddy.near --wrap-near-id wrap.near --ft-account-id usdt.tether-token.near --exchange-id v2.ref-finance.near --mpc-contract-id v1.signer-prod.testnet --pool-id 3879
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/main --mode run --transaction-kind=mpc-sign --rpc-url 'https://rpc.testnet.near.org' --signer-id and7.testnet --signer-key 'ed25519:3auVhHdg4ZgJ6KGLZ8n9mY1Rkczw9KfubH7tpGa48wjTZw2sm98PPghZwLpfmQroTVpbAbrXFnoXRNV5pphZfTCx' --receiver-id tx-bench-buddy.near --wrap-near-id wrap.near --ft-account-id usdt.tether-token.near --exchange-id v2.ref-finance.near --mpc-contract-id v1.signer-prod.testnet --pool-id 3879`
2025-04-17T14:37:38.722527Z  INFO configuration: Opts { mode: Run, rpc_url: "https://rpc.testnet.near.org", signer_id: AccountId("and7.testnet"), signer_key: ED25519(myprivatekey), receiver_id: AccountId("tx-bench-buddy.near"), wrap_near_id: AccountId("wrap.near"), ft_account_id: AccountId("usdt.tether-token.near"), exchange_id: AccountId("v2.ref-finance.near"), mpc_contract_id: AccountId("v1.signer-prod.testnet"), pool_id: 3879, transaction_kind: [MpcSign], repeats_number: 1, period: 900s, metric_server_address: 0.0.0.0:9000, location: "unknown" }
2025-04-17T14:37:38.722809Z  INFO starting metrics server on 0.0.0.0:9000
2025-04-17T14:37:38.723777Z  INFO starting transaction engine
2025-04-17T14:37:38.724999Z  INFO running selected transactions: [MpcSign]
2025-04-17T14:37:39.065327Z  INFO executing transaction mpc-sign#0 for and7.testnet
2025-04-17T14:37:43.317730Z  INFO completed transaction mpc-sign#0 for and7.testnet: 4.252173958s
```

Resulting sign tx: https://testnet.nearblocks.io/txns/DBrsFpi7B8frprkCGrAeBR47nBn5FQcwvA9YngPoEpM?tab=execution#GTEqPjMTYQyjow21fCW8N38dfimTWZbx7Q9a3z6roQew

