### PR TITLE
Better nonce handling

### DIFF
--- a/src/transaction/engine.rs
+++ b/src/transaction/engine.rs
@@ -148,9 +148,9 @@ impl Engine {
             let transactions_clone = transactions.clone();
 
             tasks.spawn(async move {
-                // Add 2 second delay between each interval group start
+                // Add 3 second delay between each interval group start
                 if task_id > 0 {
-                    tokio::time::sleep(tokio::time::Duration::from_secs(5 * task_id as u64)).await;
+                    tokio::time::sleep(tokio::time::Duration::from_secs(3 * task_id as u64)).await;
                 }
                 
                 let mut interval = interval(interval_duration);

--- a/src/transaction/engine.rs
+++ b/src/transaction/engine.rs
@@ -142,12 +142,17 @@ impl Engine {
         }
 
         // Spawn a task for each interval group
-        for (interval_duration, transaction_kinds) in interval_groups {
+        for (task_id, (interval_duration, transaction_kinds)) in interval_groups.into_iter().enumerate() {
             let opts_clone = opts.clone();
             let metrics_clone = metrics.clone();
             let transactions_clone = transactions.clone();
 
             tasks.spawn(async move {
+                // Add 2 second delay between each interval group start
+                if task_id > 0 {
+                    tokio::time::sleep(tokio::time::Duration::from_secs(5 * task_id as u64)).await;
+                }
+                
                 let mut interval = interval(interval_duration);
                 loop {
                     interval.tick().await;

--- a/src/transaction/engine.rs
+++ b/src/transaction/engine.rs
@@ -142,7 +142,9 @@ impl Engine {
         }
 
         // Spawn a task for each interval group
-        for (task_id, (interval_duration, transaction_kinds)) in interval_groups.into_iter().enumerate() {
+        for (task_id, (interval_duration, transaction_kinds)) in
+            interval_groups.into_iter().enumerate()
+        {
             let opts_clone = opts.clone();
             let metrics_clone = metrics.clone();
             let transactions_clone = transactions.clone();
@@ -152,7 +154,7 @@ impl Engine {
                 if task_id > 0 {
                     tokio::time::sleep(tokio::time::Duration::from_secs(3 * task_id as u64)).await;
                 }
-                
+
                 let mut interval = interval(interval_duration);
                 loop {
                     interval.tick().await;


### PR DESCRIPTION
Fix for errors:
`error during transaction mpc-sign#0 for tx-bench.testnet: Call MPC sign function failed: handler error: [An error happened during transaction execution: InvalidNonce { tx_nonce: 161421458262872, ak_nonce: 161421458262872 }]`

This short delay between interval groups allows for each interval to get their own non-conflicting nonce 