### PR TITLE
Variable group_delay

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -65,7 +65,7 @@ pub struct Opts {
     #[clap(env, short, long, value_parser = humantime::parse_duration, default_value = "15m")]
     pub period: std::time::Duration,
     /// Time delay between each intervalgroup of transactions
-    #[clap(env, short, long, value_parser = humantime::parse_duration, default_value = "3s")]
+    #[clap(env, short, long, value_parser = humantime::parse_duration, default_value = "5s")]
     pub group_delay: std::time::Duration,
     /// Override intervals for specific transaction types (JSON format: {"MpcSign": "5m", "Swap": "10m"})
     #[clap(env, long, value_parser = parse_interval_overwrite)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,6 +64,9 @@ pub struct Opts {
     /// Time difference between benchmarking runs
     #[clap(env, short, long, value_parser = humantime::parse_duration, default_value = "15m")]
     pub period: std::time::Duration,
+    /// Time delay between each intervalgroup of transactions
+    #[clap(env, short, long, value_parser = humantime::parse_duration, default_value = "3s")]
+    pub group_delay: std::time::Duration,
     /// Override intervals for specific transaction types (JSON format: {"MpcSign": "5m", "Swap": "10m"})
     #[clap(env, long, value_parser = parse_interval_overwrite)]
     pub interval_overwrite: Option<HashMap<TransactionKind, std::time::Duration>>,

--- a/src/transaction/engine.rs
+++ b/src/transaction/engine.rs
@@ -114,6 +114,8 @@ impl Engine {
         // Clone necessary data before borrowing
         let transactions = self.transactions.clone();
         let default_interval = opts.period;
+        let group_delay = opts.group_delay;
+        info!("group delay: {:?}", group_delay);
 
         // Group transactions by their intervals
         let mut interval_groups: HashMap<std::time::Duration, Vec<TransactionKind>> =
@@ -152,7 +154,7 @@ impl Engine {
             tasks.spawn(async move {
                 // Add 3 second delay between each interval group start
                 if task_id > 0 {
-                    tokio::time::sleep(tokio::time::Duration::from_secs(3 * task_id as u64)).await;
+                    tokio::time::sleep(group_delay).await;
                 }
 
                 let mut interval = interval(interval_duration);
@@ -438,6 +440,7 @@ mod tests {
             pool_id: 0,
             transaction_kind: vec![],
             period: Duration::from_millis(1),
+            group_delay: Duration::from_secs(3),
             interval_overwrite: None,
             metric_server_address: SocketAddr::from_str("0.0.0.0:9000").unwrap(),
             location: LOCATION.to_string(),


### PR DESCRIPTION
this is required because mainnet and testnet are moving at different rates and there are still nonce conflicts